### PR TITLE
Add configuration option to allow auto upgrade of anonymous users

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,15 @@ You can control whether new users can sign in or not by using the option `allowN
   };
 ```
 
+### Anonymous User upgrade Settings
+When an anonymous user signs in or signs up with a permanent account, the `allowAutoUpgradeAnonymousUsers` option allows you to link the existing account (anonymous) with permanent account. This way the user can continue with what they were doing before signing up. By default this option is disabled.
+```javascript
+  const config = {
+    ...
+    allowAutoUpgradeAnonymousUsers: true,
+  };
+```
+
 ## Example Project
 
 Create a project in the [Firebase Console](https://console.firebase.google.com) and add apps for Android and iOS. Then enable Email/Password provider in Authentication.

--- a/README.md
+++ b/README.md
@@ -222,11 +222,11 @@ You can control whether new users can sign in or not by using the option `allowN
 ```
 
 ### Anonymous User upgrade Settings
-When an anonymous user signs in or signs up with a permanent account, the `allowAutoUpgradeAnonymousUsers` option allows you to link the existing account (anonymous) with permanent account. This way the user can continue with what they were doing before signing up. By default this option is disabled.
+When an anonymous user signs in or signs up with a permanent account, the `autoUpgradeAnonymousUsers` option allows you to link the existing account (anonymous) with permanent account. This way the user can continue with what they were doing before signing up. By default this option is disabled.
 ```javascript
   const config = {
     ...
-    allowAutoUpgradeAnonymousUsers: true,
+    autoUpgradeAnonymousUsers: true,
   };
 ```
 

--- a/android/src/main/java/com/oijusti/firebaseuiauth/RNFirebaseuiAuthModule.java
+++ b/android/src/main/java/com/oijusti/firebaseuiauth/RNFirebaseuiAuthModule.java
@@ -114,7 +114,6 @@ public class RNFirebaseuiAuthModule extends ReactContextBaseJavaModule {
     }
 
     AuthUI.SignInIntentBuilder builder = AuthUI.getInstance().createSignInIntentBuilder();
-
     if (cfgCustomizations != null) {
       try {
         PackageManager pm = reactContext.getPackageManager();
@@ -136,7 +135,7 @@ public class RNFirebaseuiAuthModule extends ReactContextBaseJavaModule {
       } catch (PackageManager.NameNotFoundException e) { }
     }
 
-    if (allowAutoUpgradeAnonymousUsers){
+    if (allowAutoUpgradeAnonymousUsers) {
       builder = builder.enableAnonymousUsersAutoUpgrade();
     }
 

--- a/android/src/main/java/com/oijusti/firebaseuiauth/RNFirebaseuiAuthModule.java
+++ b/android/src/main/java/com/oijusti/firebaseuiauth/RNFirebaseuiAuthModule.java
@@ -70,6 +70,7 @@ public class RNFirebaseuiAuthModule extends ReactContextBaseJavaModule {
     final String privacyPolicyUrl = config.hasKey("privacyPolicyUrl") ? config.getString("privacyPolicyUrl") : null;
     final boolean allowNewEmailAccounts = !config.hasKey("allowNewEmailAccounts") || config.getBoolean("allowNewEmailAccounts");
     final boolean requireDisplayName = !config.hasKey("requireDisplayName") || config.getBoolean("requireDisplayName");
+    final boolean allowAutoUpgradeAnonymousUsers = config.hasKey("allowAutoUpgradeAnonymousUsers") ? config.getBoolean("allowAutoUpgradeAnonymousUsers") : false;
 
     final List<AuthUI.IdpConfig> providers = new ArrayList<>();
 
@@ -113,6 +114,7 @@ public class RNFirebaseuiAuthModule extends ReactContextBaseJavaModule {
     }
 
     AuthUI.SignInIntentBuilder builder = AuthUI.getInstance().createSignInIntentBuilder();
+
     if (cfgCustomizations != null) {
       try {
         PackageManager pm = reactContext.getPackageManager();
@@ -132,6 +134,10 @@ public class RNFirebaseuiAuthModule extends ReactContextBaseJavaModule {
           }
         }
       } catch (PackageManager.NameNotFoundException e) { }
+    }
+
+    if (allowAutoUpgradeAnonymousUsers){
+      builder = builder.enableAnonymousUsersAutoUpgrade();
     }
 
     currentActivity.startActivityForResult(

--- a/android/src/main/java/com/oijusti/firebaseuiauth/RNFirebaseuiAuthModule.java
+++ b/android/src/main/java/com/oijusti/firebaseuiauth/RNFirebaseuiAuthModule.java
@@ -70,7 +70,7 @@ public class RNFirebaseuiAuthModule extends ReactContextBaseJavaModule {
     final String privacyPolicyUrl = config.hasKey("privacyPolicyUrl") ? config.getString("privacyPolicyUrl") : null;
     final boolean allowNewEmailAccounts = !config.hasKey("allowNewEmailAccounts") || config.getBoolean("allowNewEmailAccounts");
     final boolean requireDisplayName = !config.hasKey("requireDisplayName") || config.getBoolean("requireDisplayName");
-    final boolean allowAutoUpgradeAnonymousUsers = config.hasKey("allowAutoUpgradeAnonymousUsers") ? config.getBoolean("allowAutoUpgradeAnonymousUsers") : false;
+    final boolean autoUpgradeAnonymousUsers = config.hasKey("autoUpgradeAnonymousUsers") && config.getBoolean("autoUpgradeAnonymousUsers");
 
     final List<AuthUI.IdpConfig> providers = new ArrayList<>();
 
@@ -135,8 +135,8 @@ public class RNFirebaseuiAuthModule extends ReactContextBaseJavaModule {
       } catch (PackageManager.NameNotFoundException e) { }
     }
 
-    if (allowAutoUpgradeAnonymousUsers) {
-      builder = builder.enableAnonymousUsersAutoUpgrade();
+    if (autoUpgradeAnonymousUsers) {
+      builder.enableAnonymousUsersAutoUpgrade();
     }
 
     currentActivity.startActivityForResult(

--- a/ios/RNFirebaseuiAuth.m
+++ b/ios/RNFirebaseuiAuth.m
@@ -57,6 +57,7 @@ RCT_EXPORT_METHOD(signIn:(NSDictionary *)config
     NSArray<NSString *> *cfgCustomizations = [config objectForKey:@"customizations"];
     BOOL allowNewEmailAccounts = [config valueForKey:@"allowNewEmailAccounts"] ? [[config valueForKey:@"allowNewEmailAccounts"] integerValue] : 1;
     BOOL requireDisplayName = [config valueForKey:@"requireDisplayName"] ? [[config valueForKey:@"requireDisplayName"] integerValue] : 1;
+    BOOL allowAutoUpgradeAnonymousUsers = [config valueForKey:@"allowAutoUpgradeAnonymousUsers"] ? [[config valueForKey:@"allowAutoUpgradeAnonymousUsers"] integerValue] : 0;
 
     for (int i = 0; i < [cfgProviders count]; i++)
     {
@@ -127,6 +128,7 @@ RCT_EXPORT_METHOD(signIn:(NSDictionary *)config
     self.authUI.providers = providers;
     self.authUI.TOSURL = [NSURL URLWithString:config[@"tosUrl"]];
     self.authUI.privacyPolicyURL = [NSURL URLWithString:config[@"privacyPolicyUrl"]];
+    self.authUI.autoUpgradeAnonymousUsers = allowAutoUpgradeAnonymousUsers;
     
     UINavigationController *authViewController = [self.authUI authViewController];
     UIViewController *rootVC = UIApplication.sharedApplication.delegate.window.rootViewController;

--- a/ios/RNFirebaseuiAuth.m
+++ b/ios/RNFirebaseuiAuth.m
@@ -57,7 +57,7 @@ RCT_EXPORT_METHOD(signIn:(NSDictionary *)config
     NSArray<NSString *> *cfgCustomizations = [config objectForKey:@"customizations"];
     BOOL allowNewEmailAccounts = [config valueForKey:@"allowNewEmailAccounts"] ? [[config valueForKey:@"allowNewEmailAccounts"] integerValue] : 1;
     BOOL requireDisplayName = [config valueForKey:@"requireDisplayName"] ? [[config valueForKey:@"requireDisplayName"] integerValue] : 1;
-    BOOL allowAutoUpgradeAnonymousUsers = [config valueForKey:@"allowAutoUpgradeAnonymousUsers"] ? [[config valueForKey:@"allowAutoUpgradeAnonymousUsers"] integerValue] : 0;
+    BOOL autoUpgradeAnonymousUsers = [config valueForKey:@"autoUpgradeAnonymousUsers"] ? [[config valueForKey:@"autoUpgradeAnonymousUsers"] integerValue] : 0;
 
     for (int i = 0; i < [cfgProviders count]; i++)
     {
@@ -128,7 +128,7 @@ RCT_EXPORT_METHOD(signIn:(NSDictionary *)config
     self.authUI.providers = providers;
     self.authUI.TOSURL = [NSURL URLWithString:config[@"tosUrl"]];
     self.authUI.privacyPolicyURL = [NSURL URLWithString:config[@"privacyPolicyUrl"]];
-    self.authUI.autoUpgradeAnonymousUsers = allowAutoUpgradeAnonymousUsers;
+    self.authUI.autoUpgradeAnonymousUsers = autoUpgradeAnonymousUsers;
     
     UINavigationController *authViewController = [self.authUI authViewController];
     UIViewController *rootVC = UIApplication.sharedApplication.delegate.window.rootViewController;


### PR DESCRIPTION
**Issue Description:** Anonymous users auto upgrade is not working.

**Steps to reproduce:**
1. Enable Anonymous login in the config
2. Login with anonymous user/continue as guest
3. Attempt to upgrade or sign in with permanent account
4. New user account with permanent account details is created and old anonymous user progress is lost(but the anonymous user remains in Auth)

**Feature Enhancement:**
Expose a configuration option ```allowAutoUpgradeAnonymousUsers``` to allow the anonymous user linking to the permanent account

**Reference:**
https://github.com/firebase/FirebaseUI-Android/blob/master/auth/README.md#enabling-anonymous-user-upgrade
https://github.com/firebase/FirebaseUI-iOS/tree/master/FirebaseAuthUI#handling-auto-upgrade-of-anonymous-users
 